### PR TITLE
CDPD-44504: Save log files for first 10 failures

### DIFF
--- a/job-dsl/hive.Jenkinsfile
+++ b/job-dsl/hive.Jenkinsfile
@@ -350,7 +350,7 @@ cdpd-patcher hive $VERSION
 
         buildHive("install -Dtest=TestParseDriver#nonExistent","retry 3")
         buildHive("org.apache.maven.plugins:maven-dependency-plugin:get -Dartifact=org.apache.maven.plugins:maven-antrun-plugin:1.8","retry 3")
-        
+
       }
 
       stage('Upload') {
@@ -410,17 +410,17 @@ reinit_metastore $dbType
           stage('PostProcess') {
             try {
               sh """#!/bin/bash -e
-                FAILED_FILES=`find . -name "TEST*xml" -exec grep -l "<failure" {} \\; 2>/dev/null | head -n 10` 
+                FAILED_FILES=`find . -name "TEST*xml" -exec grep -l "<failure" {} \\; 2>/dev/null | head -n 10`
                 for a in \$FAILED_FILES
-                do  
+                do
                   RENAME_TMP=`echo \$a | sed s/TEST-//g`
                   mv \${RENAME_TMP/.xml/-output.txt} \${RENAME_TMP/.xml/-output-save.txt}
                 done
                 # removes all stdout and err for passed tests
                 xmlstarlet ed -L -d 'testsuite/testcase/system-out[count(../failure)=0]' -d 'testsuite/testcase/system-err[count(../failure)=0]' `find . -name 'TEST*xml' -path '*/surefire-reports/*'`
                 # remove all output.txt files
-                find . -name '*output.txt' -path '*/surefire-reports/*' -exec unlink "{}" \\; 
-              """ 
+                find . -name '*output.txt' -path '*/surefire-reports/*' -exec unlink "{}" \\;
+              """
             } finally {
               def fn="${splitName}.tgz"
               if (env.IS_HEALTHCHECK && currentBuild.currentResult != 'SUCCESS') {

--- a/job-dsl/hive.Jenkinsfile
+++ b/job-dsl/hive.Jenkinsfile
@@ -350,7 +350,6 @@ cdpd-patcher hive $VERSION
 
         buildHive("install -Dtest=TestParseDriver#nonExistent","retry 3")
         buildHive("org.apache.maven.plugins:maven-dependency-plugin:get -Dartifact=org.apache.maven.plugins:maven-antrun-plugin:1.8","retry 3")
-
       }
 
       stage('Upload') {

--- a/job-dsl/hive.Jenkinsfile
+++ b/job-dsl/hive.Jenkinsfile
@@ -410,11 +410,17 @@ reinit_metastore $dbType
           stage('PostProcess') {
             try {
               sh """#!/bin/bash -e
+                FAILED_FILES=`find . -name "TEST*xml" -exec grep -l "<failure" {} \\; 2>/dev/null | head -n 10` 
+                for a in \$FAILED_FILES
+                do  
+                  RENAME_TMP=`echo \$a | sed s/TEST-//g`
+                  mv \${RENAME_TMP/.xml/-output.txt} \${RENAME_TMP/.xml/-output-save.txt}
+                done
                 # removes all stdout and err for passed tests
                 xmlstarlet ed -L -d 'testsuite/testcase/system-out[count(../failure)=0]' -d 'testsuite/testcase/system-err[count(../failure)=0]' `find . -name 'TEST*xml' -path '*/surefire-reports/*'`
                 # remove all output.txt files
-                find . -name '*output.txt' -path '*/surefire-reports/*' -exec unlink "{}" \\;
-              """
+                find . -name '*output.txt' -path '*/surefire-reports/*' -exec unlink "{}" \\; 
+              """ 
             } finally {
               def fn="${splitName}.tgz"
               if (env.IS_HEALTHCHECK && currentBuild.currentResult != 'SUCCESS') {


### PR DESCRIPTION
The first 10 failures in the precommit tests will now be saved in the artifcats on Jenkins.