### PR TITLE
Adapt htk-jenkins based on latest jenkins image

### DIFF
--- a/htk-jenkins/Dockerfile
+++ b/htk-jenkins/Dockerfile
@@ -1,14 +1,14 @@
 FROM jenkins/jenkins:lts
 
-#RUN /usr/local/bin/install-plugins.sh github-api:1.111
-RUN /usr/local/bin/install-plugins.sh git ansicolor github build-name-setter timestamper kubernetes
+#RUN jenkins-plugin-cli --plugins  github-api:1.111
+RUN jenkins-plugin-cli --plugins git ansicolor github build-name-setter timestamper kubernetes
 # some issue with service; 
-RUN /usr/local/bin/install-plugins.sh maven-plugin:3.4
-RUN /usr/local/bin/install-plugins.sh parallel-test-executor
-RUN /usr/local/bin/install-plugins.sh junit-realtime-test-reporter blueocean
-RUN /usr/local/bin/install-plugins.sh build-timeout config-file-provider rebuild junit copyartifact 
-RUN /usr/local/bin/install-plugins.sh metrics
-RUN /usr/local/bin/install-plugins.sh antisamy-markup-formatter slack github-oauth throttle-concurrents lockable-resources pipeline-github envinject build-environment schedule-build matrix-auth
+RUN jenkins-plugin-cli --plugins maven-plugin
+RUN jenkins-plugin-cli --plugins parallel-test-executor
+RUN jenkins-plugin-cli --plugins junit-realtime-test-reporter blueocean
+RUN jenkins-plugin-cli --plugins build-timeout config-file-provider rebuild junit copyartifact 
+RUN jenkins-plugin-cli --plugins metrics
+RUN jenkins-plugin-cli --plugins antisamy-markup-formatter slack github-oauth throttle-concurrents lockable-resources pipeline-github envinject build-environment schedule-build matrix-auth
 USER root
 RUN apt-get update && apt-get install -y nano curl nmap make git less && apt-get clean
 #USER root

--- a/htk-jenkins/entrypoint
+++ b/htk-jenkins/entrypoint
@@ -5,11 +5,11 @@ if [ ! -s /var/jenkins_home/config.xml ];then
 	cp -r /var/jenkins_home_default/./ /var/jenkins_home/
 fi
 export JAVA_OPTS+=" -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator.websocketConnectionTimeout=180"
-export JAVA_OPTS+=" -Xloggc:$JENKINS_HOME/gc-%t.log -XX:NumberOfGCLogFiles=5 -XX:+UseGCLogFileRotation -XX:GCLogFileSize=20m -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintHeapAtGC -XX:+PrintGCCause -XX:+PrintTenuringDistribution -XX:+PrintReferenceGC -XX:+PrintAdaptiveSizePolicy"
+export JAVA_OPTS+=" -Xlog:gc:$JENKINS_HOME/gc-%t.log -Xlog:gc* -Xlog:gc+heap=trace -Xlog:age*=debug -Xlog:ref*=trace -Xlog:ergo*=trace"
 export JAVA_OPTS+=" -server -Xms4g -Xmx8g"
 
 if [ "$1" == "" ];then
-	exec /sbin/tini -- /usr/local/bin/jenkins.sh
+	exec /usr/bin/tini -- /usr/local/bin/jenkins.sh
 else
 	exec "$@"
 fi

--- a/htk-jenkins/entrypoint
+++ b/htk-jenkins/entrypoint
@@ -5,7 +5,7 @@ if [ ! -s /var/jenkins_home/config.xml ];then
 	cp -r /var/jenkins_home_default/./ /var/jenkins_home/
 fi
 export JAVA_OPTS+=" -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator.websocketConnectionTimeout=180"
-export JAVA_OPTS+=" -Xlog:gc:$JENKINS_HOME/gc-%t.log -Xlog:gc* -Xlog:gc+heap=trace -Xlog:age*=debug -Xlog:ref*=trace -Xlog:ergo*=trace"
+export JAVA_OPTS+=" -Xlog:gc*,safepoint:$JENKINS_HOME/gc-%t.log:time,uptime:filecount=5,filesize=20M"
 export JAVA_OPTS+=" -server -Xms4g -Xmx8g"
 
 if [ "$1" == "" ];then


### PR DESCRIPTION
Currently it is not possible to build a new htk-jenkins image
```
docker build -t kgyrtkirk/htk-jenkins htk-jenkins
```
cause the base image jenkins/jenkins:lts has changed singificantly.

1. The install-plugins.sh script was deprecated and jenkins-plugin-cli should be used instead.
2. `tini` executable changed location and is no longer under `/sbin/tini`
```
 @ setting jenkins defaults
/entrypoint: line 12: /sbin/tini: No such file or directory
```
3. The current jenkins image uses a newer JDK where the Xloggc options are deprecated/removed causing failures when launching the container.
```
Unrecognized VM option 'NumberOfGCLogFiles=5'
[0.000s][warning][gc] -Xloggc is deprecated. Will use -Xlog:gc:/var/jenkins_home/gc-%t.log instead.
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```
4. The maven-plugin 3.4 version is too old causing errors in other plugins that were updated.

With the changes in this commit the hkt-jenkins image can be built sucessfully and the container can start sucessfully without notable problems.