### PR TITLE
Using managed cert for ingress

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -4,6 +4,7 @@ metadata:
   name: htk-ingress
   annotations:
     kubernetes.io/ingress.global-static-ip-name: "hive-test-kube-ip"
+    networking.gke.io/managed-certificates: managed-cert
 spec:
   backend:
     serviceName: jenkins

--- a/k8s/managed-cert.yaml
+++ b/k8s/managed-cert.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: managed-cert
+spec:
+  domains:
+    - ci.hive.apache.org


### PR DESCRIPTION
Last friday, ci.hive.apache.org suddenly stopped loading in my browser, despite that all affected k8s components were healthy. Created https://issues.apache.org/jira/browse/INFRA-25835, where it turned out, the DNS entry is also correct and points to the static external IP of the hive precommit cluster (130.211.9.232).
Not sure what actually changed, but finally I was able to manage this in a very elegant way:
1. created a managed certificate
2. declared that in the ingress

when the certificate turned from PROVISIONING to ACTIVE, the https endpoint immediately started to work again, took care of TLS termination and forwarded to the jenkins service as expected
https://ci.hive.apache.org/

I think we should store the changes in version control